### PR TITLE
APSR-1052 Override the reactivemongo driver dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,10 @@ val compile = Seq(
   "uk.gov.hmrc" %% "simple-reactivemongo" % "7.19.0-play-25"
 )
 
+val overrides = Seq(
+  "org.reactivemongo" %% "reactivemongo" % "0.16.6"
+)
+
 def test(scope: String = "test,acceptance") = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.8.0-play-25" % scope,
   "uk.gov.hmrc" %% "reactivemongo-test" % "4.13.0-play-25" % scope,
@@ -44,7 +48,7 @@ def test(scope: String = "test,acceptance") = Seq(
 
 val appName = "api-subscription-fields"
 
-lazy val appDependencies: Seq[ModuleID] = compile ++ test()
+lazy val appDependencies: Seq[ModuleID] = compile ++ overrides ++ test()
 
 resolvers ++= Seq(Resolver.bintrayRepo("hmrc", "releases"), Resolver.jcenterRepo)
 


### PR DESCRIPTION
Override the reactivemongo driver dependency to 0.16.6 from 0.16.4 to see if this fixes the connectivity problem we see in QA.