### PR TITLE
CDD-3415 Add test route for inserting fieldsId

### DIFF
--- a/app/uk/gov/hmrc/apisubscriptionfields/controller/testonly/TestOnlySubscriptionFieldsController.scala
+++ b/app/uk/gov/hmrc/apisubscriptionfields/controller/testonly/TestOnlySubscriptionFieldsController.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apisubscriptionfields.controller.testonly
+
+import play.api.libs.json._
+import play.api.mvc._
+import uk.gov.hmrc.apisubscriptionfields.controller.{CommonController, SubscriptionFieldsController, SubscriptionFieldsRequest}
+import uk.gov.hmrc.apisubscriptionfields.model.Types.Fields
+import uk.gov.hmrc.apisubscriptionfields.model._
+import uk.gov.hmrc.apisubscriptionfields.repository.SubscriptionFieldsRepository
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TestOnlySubscriptionFieldsController @Inject()(cc: ControllerComponents,
+                                                     repository: SubscriptionFieldsRepository)
+                                                    (implicit ec: ExecutionContext) extends CommonController {
+
+  def upsertSubscriptionFields(clientId: ClientId, apiContext: ApiContext, apiVersion: ApiVersion,
+                               fieldsId: SubscriptionFieldsId): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    import JsonFormatters._
+    withJsonBody[SubscriptionFieldsRequest] { payload =>
+      for {
+        upserted <- upsertSubscriptionFields(clientId, apiContext, apiVersion, payload.fields, fieldsId)
+        response = upserted match {
+          case SuccessfulSubsFieldsUpsertResponse(response, true)  => Created(Json.toJson(response))
+          case SuccessfulSubsFieldsUpsertResponse(response, false) => Ok(Json.toJson(response))
+        }
+      } yield response
+    }
+  }
+
+  private def upsertSubscriptionFields(clientId: ClientId, apiContext: ApiContext, apiVersion: ApiVersion,
+                                       fields: Fields, fieldsId: SubscriptionFieldsId): Future[SuccessfulSubsFieldsUpsertResponse] = {
+    val subscriptionFields = SubscriptionFields(clientId, apiContext, apiVersion, fieldsId, fields)
+
+    repository.saveAtomic(subscriptionFields)
+      .map { case (subsFields, isInsert) =>
+        SuccessfulSubsFieldsUpsertResponse(subsFields, isInsert)
+      }
+  }
+
+  protected def controllerComponents: ControllerComponents = cc
+}

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc.versioning.SbtGitVersioning
 import bloop.integrations.sbt.BloopDefaults
+import play.sbt.PlayImport.PlayKeys.playDefaultPort
 
 import scala.language.postfixOps
 
@@ -30,7 +31,7 @@ val appName = "api-subscription-fields"
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots")
-  )
+)
 
 lazy val plugins: Seq[Plugins] = Seq(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
 lazy val playSettings: Seq[Setting[_]] = Seq.empty
@@ -64,10 +65,11 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(majorVersion := 0)
   .settings(scalacOptions ++= Seq("-Ypartial-unification"))
+  .settings(playDefaultPort := 9650)
 
 lazy val acceptanceTestSettings =
   inConfig(AcceptanceTest)(Defaults.testSettings) ++
-  inConfig(AcceptanceTest)(BloopDefaults.configSettings) ++
+    inConfig(AcceptanceTest)(BloopDefaults.configSettings) ++
     Seq(
       unmanagedSourceDirectories in AcceptanceTest := Seq(baseDirectory.value / "acceptance"),
       fork in AcceptanceTest := false,

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val appName = "api-subscription-fields"
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots")
-)
+  )
 
 lazy val plugins: Seq[Plugins] = Seq(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
 lazy val playSettings: Seq[Setting[_]] = Seq.empty
@@ -67,7 +67,7 @@ lazy val microservice = Project(appName, file("."))
 
 lazy val acceptanceTestSettings =
   inConfig(AcceptanceTest)(Defaults.testSettings) ++
-    inConfig(AcceptanceTest)(BloopDefaults.configSettings) ++
+  inConfig(AcceptanceTest)(BloopDefaults.configSettings) ++
     Seq(
       unmanagedSourceDirectories in AcceptanceTest := Seq(baseDirectory.value / "acceptance"),
       fork in AcceptanceTest := false,

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc.versioning.SbtGitVersioning
 import bloop.integrations.sbt.BloopDefaults
-import play.sbt.PlayImport.PlayKeys.playDefaultPort
 
 import scala.language.postfixOps
 
@@ -65,7 +64,6 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(majorVersion := 0)
   .settings(scalacOptions ++= Seq("-Ypartial-unification"))
-  .settings(playDefaultPort := 9650)
 
 lazy val acceptanceTestSettings =
   inConfig(AcceptanceTest)(Defaults.testSettings) ++

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,5 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+PUT        /api-subscription-fields/test-only/field/application/:clientId/context/:apiContext/version/:apiVersion/fieldsId/:fieldsId     uk.gov.hmrc.apisubscriptionfields.controller.testonly.TestOnlySubscriptionFieldsController.upsertSubscriptionFields(clientId: ClientId, apiContext: ApiContext, apiVersion: ApiVersion, fieldsId: SubscriptionFieldsId)


### PR DESCRIPTION
It adds a test-route which allow to upsert subscriptionFields with a specific fieldsId. It is useful for performance tests which can use pre-defined fieldsId.